### PR TITLE
mpd V.<021 empty Album List bug - pushUp Play added Position slider

### DIFF
--- a/qml/components/ControlPanel.qml
+++ b/qml/components/ControlPanel.qml
@@ -95,6 +95,14 @@ DockedPanel {
     PushUpMenu {
         id: pushUp
 
+        PositionSlider {
+            id: positionSlider
+            width: parent.width
+            onPressedChanged: {
+                mPositionSliderActive = pressed
+            }
+        }
+
         PlaybackControls {}
 
         VolumeSlider {

--- a/src/mpd/networkaccess.cpp
+++ b/src/mpd/networkaccess.cpp
@@ -183,13 +183,15 @@ QList<MpdAlbum *> *NetworkAccess::parseMPDAlbums(QString listedArtist = nullptr)
                     QQmlEngine::setObjectOwnership(tempalbum, QQmlEngine::CppOwnership);
                     albums->append(tempalbum);
                 }
-
+                // remember previous name, workaround for albums displayed multiple times when song name per album are not unique
+                // old mdp - like in volumio distribution - shows empty album list if 'name_old = name' is behind 'name = _name;'
+                // doit before: name = _name;
+                name_old = name;
                 /* set new name for old list format */
                 name = _name;
                 /* set new name for old list format */
                 skipFirstAlbum = false;
-                // remember previous name, workaround for albums displayed multiple times when song name per album are not unique
-                name_old = name;
+
             }
         }
     }


### PR DESCRIPTION
Hi
patch for Bug with old mpd <0.21 (like in volumio)
Album List was empty
and
added position slider to pushUp ControlPanel
(because i like it there...)