### PR TITLE
Radioplaylist readable - little fixes

### DIFF
--- a/src/mpd/mpdtrack.cpp
+++ b/src/mpd/mpdtrack.cpp
@@ -135,7 +135,20 @@ QString MpdTrack::getFileName() const {
     splitted = getFileUri().split('/');
     return (splitted.last() !="" ? splitted.last() : getFileUri());
 }
-
+/*
+QString MpdTrack::getFileName() const {
+    QStringList splitted;
+    QString fileUri = getFileUri();
+    if (fileUri.toLower().startsWith("http://") || fileUri.toLower().startsWith("https://")) {
+        splitted = fileUri.split('#');
+        if (splitted.last() !="") {
+           return splitted.last();
+        }
+    }
+    splitted = fileUri.split('/');
+    return (splitted.last() !="" ? splitted.last() : getFileUri());
+}
+*/
 QString MpdTrack::getTrackMBID() const {
     return mTrackMBID;
 }


### PR DESCRIPTION
Hi
made m3u and cantata Radio playlist better readable  and fixed 2 little memory leaks
did a rewrite for NetworkAccess::parseMPDTracks.
Works for me and shouldn't introduce any trouble but please
check...
u can work with cantata or Downloading m3u Radioplaylists directly to /var/lib/mpd/playlist
