### PR TITLE
Sort tracks in album client-side by disc number and track number

### DIFF
--- a/src/mpd/filemodel.cpp
+++ b/src/mpd/filemodel.cpp
@@ -60,6 +60,8 @@ QVariant FileModel::data(const QModelIndex &index, int role) const
         return mEntries->at(index.row())->getArtistMBID();
     else if(role==tracknoRole)
         return mEntries->at(index.row())->getTrackNr();
+    else if(role==discoNoRole)
+        return mEntries->at(index.row())->getDiscNr();
     else if(role==genreRole)
         return mEntries->at(index.row())->getGenre();
     else if(role==yearRole)
@@ -139,6 +141,7 @@ QHash<int, QByteArray> FileModel::roleNames() const {
     roles[albummbidRole] = "albummbid";
     roles[artistmbidRole] = "artistmbid";
     roles[genreRole] = "genre";
+    roles[discoNoRole] = "discnr";
 
     return roles;
 }

--- a/src/mpd/filemodel.h
+++ b/src/mpd/filemodel.h
@@ -43,6 +43,7 @@ public:
         albummbidRole,
         artistmbidRole,
         genreRole,
+        discoNoRole
     };
 
 private:

--- a/src/mpd/mpdfileentry.cpp
+++ b/src/mpd/mpdfileentry.cpp
@@ -133,6 +133,13 @@ int MpdFileEntry::getTrackNr() const
     return 0;
 }
 
+int MpdFileEntry::getDiscNr() const
+{
+    if(mTrack!=NULL)
+        return getTrack()->getDiscNr();
+    return 0;
+}
+
 QString MpdFileEntry::getGenre() const
 {
     if(mTrack!=NULL)

--- a/src/mpd/mpdfileentry.h
+++ b/src/mpd/mpdfileentry.h
@@ -19,6 +19,7 @@ class MpdFileEntry : public QObject
     Q_PROPERTY(QString artist READ getArtist NOTIFY changed )
     Q_PROPERTY(QString length READ getLengthFormatted NOTIFY changed )
     Q_PROPERTY(int tracknr READ getTrackNr NOTIFY changed )
+    Q_PROPERTY(int discnr READ getDiscNr NOTIFY changed )
     Q_PROPERTY(QString year READ getYear NOTIFY changed )
     Q_PROPERTY(QString genre READ getGenre NOTIFY changed )
 public:
@@ -49,6 +50,7 @@ public:
     QString getGenre() const;
 
     int getTrackNr() const;
+    int getDiscNr() const;
     bool operator< (const MpdFileEntry& other) const;
     bool operator==(MpdFileEntry & rhs);
     static bool lessThan(const MpdFileEntry *lhs, const MpdFileEntry* rhs);

--- a/src/mpd/mpdtrack.cpp
+++ b/src/mpd/mpdtrack.cpp
@@ -12,6 +12,7 @@ MpdTrack::MpdTrack(QObject *parent) :
   mFileURI="";
   mYear ="";
   mTrackNR = 0;
+  mDiscNR = 0;
   mAlbumTracks = 0;
   mPlaying = false;
 }
@@ -120,6 +121,11 @@ int MpdTrack::getTrackNr() const
     return mTrackNR;
 }
 
+int MpdTrack::getDiscNr() const
+{
+    return mDiscNR;
+}
+
 int MpdTrack::getAlbumTracks() const
 {
     return mAlbumTracks;
@@ -188,6 +194,14 @@ void MpdTrack::setPlaying(bool playing)
     emit playingchanged();
 }
 
+bool MpdTrack::lessThanTrackNr(const MpdTrack *lhs, const MpdTrack *rhs)
+{
+    if (lhs->getDiscNr() != rhs->getDiscNr()) {
+        return lhs->getDiscNr() < rhs->getDiscNr();
+    }
+    return lhs->getTrackNr() < rhs->getTrackNr();
+}
+
 void MpdTrack::setYear(QString year)
 {
     this->mYear = year;
@@ -196,6 +210,11 @@ void MpdTrack::setYear(QString year)
 void MpdTrack::setTrackNr(int nr)
 {
     this->mTrackNR = nr;
+}
+
+void MpdTrack::setDiscNr(int nr)
+{
+    this->mDiscNR = nr;
 }
 
 void MpdTrack::setAlbumTracks(int nr)

--- a/src/mpd/mpdtrack.h
+++ b/src/mpd/mpdtrack.h
@@ -22,6 +22,7 @@ class MpdTrack : public QObject
     Q_PROPERTY(QString album READ getAlbum NOTIFY changed )
     Q_PROPERTY(bool playing READ getPlaying NOTIFY playingchanged )
     Q_PROPERTY(int tracknr READ getTrackNr NOTIFY changed )
+    Q_PROPERTY(int discnr READ getDiscNr NOTIFY changed )
     Q_PROPERTY(QString year READ getYear NOTIFY changed )
     Q_PROPERTY(QString filename READ getFileName NOTIFY changed )
     Q_PROPERTY(QString trackmbid READ getTrackMBID NOTIFY changed )
@@ -46,6 +47,7 @@ public:
     QString getFileName() const;
 
     int getTrackNr() const;
+    int getDiscNr() const;
     int getAlbumTracks() const;
 
     QString getTrackMBID() const;
@@ -61,6 +63,7 @@ public:
     void setAlbumArtist(QString);
     void setYear(QString mYear);
     void setTrackNr(int nr);
+    void setDiscNr(int nr);
     void setAlbumTracks(int nr);
 
     void setTrackMBID(QString mbid);
@@ -70,6 +73,8 @@ public:
 
     bool getPlaying() const;
     void setPlaying(bool mPlaying);
+
+    static bool lessThanTrackNr(const MpdTrack *lhs, const MpdTrack* rhs);
 private:
     QString mTitle;
     QString mFileURI;
@@ -78,6 +83,7 @@ private:
     QString mAlbumArtist;
     QString mAlbum;
     int mTrackNR;
+    int mDiscNR;
     int mAlbumTracks;
     QString mYear;
 

--- a/src/mpd/networkaccess.cpp
+++ b/src/mpd/networkaccess.cpp
@@ -382,7 +382,9 @@ QList<MpdTrack *> *NetworkAccess::getAlbumTracks_prv(QString album) {
         sendMPDCommand(QString("find album \"") + escapeCommandArgument(album) +
                        "\"\n");
     }
-    return parseMPDTracks("");
+    QList<MpdTrack *> *tracks = parseMPDTracks("");
+    std::sort(tracks->begin(), tracks->end(), MpdTrack::lessThanTrackNr);
+    return tracks;
 }
 
 void NetworkAccess::getAlbumTracks(QString album, QString cartist) {
@@ -416,7 +418,9 @@ QList<MpdTrack *> *NetworkAccess::getAlbumTracks_prv(QString album,
         sendMPDCommand(
             QString("find album \"%1\"\n").arg(escapeCommandArgument(album)));
     }
-    return parseMPDTracks(cartist);
+    QList<MpdTrack *> *tracks = parseMPDTracks(cartist);
+    std::sort(tracks->begin(), tracks->end(), MpdTrack::lessThanTrackNr);
+    return tracks;
 }
 
 void NetworkAccess::getTracks() {
@@ -1537,6 +1541,7 @@ QList<MpdTrack *> *NetworkAccess::parseMPDTracks(QString cartist) {
         QString albumstring;
         QString datestring;
         int nr = 0, albumnrs = 0;
+        int discnr = 0;
         QString file = "";
         QString nextFile = "";
         QString trackMBID;
@@ -1606,6 +1611,10 @@ QList<MpdTrack *> *NetworkAccess::parseMPDTracks(QString cartist) {
                         }
                     }
                     temptrack->setTrackNr(nr);
+                } else if (response.startsWith("Disc: ")){
+                    albumstring = response.right(response.length() - 6);
+                    discnr = albumstring.toInt();
+                    temptrack->setDiscNr(discnr);
                 }
                 if ((trackNr > 1 && gotit) ||
                     (response.startsWith("OK") && trackNr > 0)) {
@@ -1643,6 +1652,7 @@ QList<MpdTrack *> *NetworkAccess::parseMPDTracks(QString cartist) {
         }
         delete (temptrack);
     }
+
     return temptracks;
 }
 

--- a/src/mpd/playlistmodel.cpp
+++ b/src/mpd/playlistmodel.cpp
@@ -77,6 +77,8 @@ QVariant PlaylistModel::data(const QModelIndex &index, int role) const
         return mEntries->at(index.row())->getArtistMBID();
     else if(role==genreRole)
         return mEntries->at(index.row())->getGenre();
+    else if(role==discnoRole)
+        return mEntries->at(index.row())->getDiscNr();
     else if ( role== sectionImageURLRole ) {
         MpdTrack *track = mEntries->at(index.row());
         QString album = track->getAlbum();
@@ -159,6 +161,7 @@ QHash<int, QByteArray> PlaylistModel::roleNames() const {
     roles[albummbidRole] = "albummbid";
     roles[artistmbidRole] = "artistmbid";
     roles[genreRole] = "genre";
+    roles[discnoRole] = "discnr";
 
     return roles;
 }

--- a/src/mpd/playlistmodel.h
+++ b/src/mpd/playlistmodel.h
@@ -44,6 +44,7 @@ public:
         albummbidRole,
         artistmbidRole,
         genreRole,
+        discnoRole,
     };
 
 private:


### PR DESCRIPTION
The MPD server sends tracks in order of date by default when running a find album "Album name" command, but not all MPD servers send it in that order. Notably, OwnTone[^1] sends them in alphabetical order of the track title. In the protocol documentation the default sort order is unspecified[^2].

To sort tracks in a standard way across different MPD servers, tracks will now be sorted in the client after receiving them by disc number and then track number. This seems to be the approach in the MPD clients Cantata and ncmpcpp as well.

To sort by disc number, the discnr property has been added to MpdTrack and MpdFileEntry. Perhaps this can be used in the UI later.

Since MPD version 0.21, the MPD server supports a "sort" parameter for the "find" command, but this is neither supported in OwnTone or Mopidy-MPD[^3], hence the choice for a client-side sort.

[^1]: https://owntone.github.io/owntone-server/
[^2]: https://mpd.readthedocs.io/en/latest/protocol.html#command-find
[^3]: https://mopidy.com/ext/mpd/